### PR TITLE
Make compatible with Greasemonkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ Sexy github gist viewer on Facebook.
 
 ![facebook_gist_viewer.png](https://github.com/shlee322/facebook-gist-viewer/blob/master/facebook_gist_viewer.png)
 
+## Using Greasemonkey (and their family)
+
+1. Install Grasemonkey / Tampermonkey / Scriptish on your browser.
+2. Click [this][userscript] to install on it.
+
+[userscript]: https://shlee322/facebook-gist-viewer/raw/master/facebook-gist.user.js
+
+
 ## Homepage
 https://github.com/shlee322/facebook-gist-viewer
 

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
     },
     "content_scripts": [
         {
-            "js": ["content.js"],
+            "js": ["facebook-gist.user.js"],
             "matches": ["https://www.facebook.com/*"]
         }
     ],


### PR DESCRIPTION
If merge this PR, It can be used on [Greasemonkey][GM]/[Tampermonkey][TM]/[Scriptish][] without standalone chrome extension. It can be useful when user do not wants to install individual plugin instead of one integrated plugin. `Userscript` is de-facto standard of this kind usage and also cross browser supported.

[GM]: https://addons.mozilla.org/ko/firefox/addon/greasemonkey/
[TM]: https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=ko
[Scriptish]: https://addons.mozilla.org/en-US/firefox/addon/scriptish/
